### PR TITLE
Removing width for basicnumber entry for current resource value

### DIFF
--- a/campaign/record_resource.xml
+++ b/campaign/record_resource.xml
@@ -36,7 +36,7 @@
 				<invisible />
 			</genericcontrol>
 			<basicnumber name="current">
-				<anchored to="leftanchor" width="20" height="20">
+				<anchored to="leftanchor" height="20">
 					<top offset="5" />
 					<left anchor="right" relation="relative" />
 				</anchored>


### PR DESCRIPTION
Allow the basic number field to just expand naturally to fit current value for the resource